### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -91,7 +91,7 @@ JAR_JVM_OPTS = shlex.split(os.getenv('STORM_JAR_JVM_OPTS', ''))
 JAVA_HOME = os.getenv('JAVA_HOME', None)
 JAVA_CMD = 'java' if not JAVA_HOME else os.path.join(JAVA_HOME, 'bin', 'java')
 if JAVA_HOME and not os.path.exists(JAVA_CMD):
-    print "ERROR:  JAVA_HOME is invalid.  Could not find bin/java at %s." % JAVA_HOME
+    print "ERROR:  JAVA_HOME is invalid.  Could not find bin/java at {0!s}.".format(JAVA_HOME)
     sys.exit(1)
 STORM_EXT_CLASSPATH = os.getenv('STORM_EXT_CLASSPATH', None)
 STORM_EXT_CLASSPATH_DAEMON = os.getenv('STORM_EXT_CLASSPATH_DAEMON', None)
@@ -483,7 +483,7 @@ def kill_workers(*args):
 
 def shell(resourcesdir, command, *args):
     tmpjarpath = "stormshell" + str(random.randint(0, 10000000)) + ".jar"
-    os.system("jar cf %s %s" % (tmpjarpath, resourcesdir))
+    os.system("jar cf {0!s} {1!s}".format(tmpjarpath, resourcesdir))
     runnerargs = [tmpjarpath, command]
     runnerargs.extend(args)
     exec_storm_class(
@@ -706,14 +706,14 @@ def print_usage(command=None):
     if command != None:
         if command in COMMANDS:
             print(COMMANDS[command].__doc__ or
-                  "No documentation provided for <%s>" % command)
+                  "No documentation provided for <{0!s}>".format(command))
         else:
-           print("<%s> is not a valid command" % command)
+           print("<{0!s}> is not a valid command".format(command))
     else:
         print_commands()
 
 def unknown_command(*args):
-    print("Unknown command: [storm %s]" % ' '.join(sys.argv[1:]))
+    print("Unknown command: [storm {0!s}]".format(' '.join(sys.argv[1:])))
     print_usage()
     sys.exit(254)
 

--- a/dev-tools/github/__init__.py
+++ b/dev-tools/github/__init__.py
@@ -104,7 +104,7 @@ class GitHub:
         self.headers = {}
         if options.gituser:
             gitpassword = getpass.getpass("github.com user " + options.gituser + ":")
-            authstr = base64.encodestring('%s:%s' % (options.gituser, gitpassword)).replace('\n', '')
+            authstr = base64.encodestring('{0!s}:{1!s}'.format(options.gituser, gitpassword)).replace('\n', '')
             self.headers["Authorization"] = "Basic " + authstr
 
     def pulls(self, user, repo, type="all"):

--- a/dev-tools/jira-github-join.py
+++ b/dev-tools/jira-github-join.py
@@ -29,7 +29,7 @@ def main():
     jira_repo = JiraRepo("https://issues.apache.org/jira/rest/api/2")
     github_repo = GitHub(options)
 
-    print "Report generated on: %s (GMT)" % (datetime.strftime(datetime.utcnow(), "%Y-%m-%d %H:%M:%S"))
+    print "Report generated on: {0!s} (GMT)".format((datetime.strftime(datetime.utcnow(), "%Y-%m-%d %H:%M:%S")))
 
     report_builder = CompleteReportBuilder(jira_repo, github_repo)
     report_builder.report.print_all()

--- a/dev-tools/jira/__init__.py
+++ b/dev-tools/jira/__init__.py
@@ -252,7 +252,7 @@ class JiraRepo:
         while (at < end):
             params = urllib.urlencode({'jql': query, 'startAt': at, 'maxResults': count})
             # print params
-            resp = urllib2.urlopen(self.baseUrl + "/search?%s" % params)
+            resp = urllib2.urlopen(self.baseUrl + "/search?{0!s}".format(params))
             data = json.loads(resp.read())
             if (data.has_key('errorMessages')):
                 raise Exception(data['errorMessages'])

--- a/dev-tools/report/report.py
+++ b/dev-tools/report/report.py
@@ -71,7 +71,7 @@ class JiraReport(Report):
         return -1, 43, -1, -1
 
     def print_report(self):
-        print "%s (Count = %s) " % (self.header, len(self.issues))
+        print "{0!s} (Count = {1!s}) ".format(self.header, len(self.issues))
         jiras = self.values_view()
         fields_tuple = ('Jira Id', 'Summary', 'Created', 'Last Updated (Days)')
         row_tuple = self._row_tuple(jiras[0])
@@ -110,7 +110,7 @@ class GitHubReport(Report):
         return -1, 43, -1, -1, -1
 
     def print_report(self):
-        print "%s (Count = %s) " % (self.header, len(self.pull_requests))
+        print "{0!s} (Count = {1!s}) ".format(self.header, len(self.pull_requests))
 
         fields_tuple = self._build_tuple(('URL', 'Title', 'Created', 'Last Updated (Days)', 'User'), '')
         if len(self.pull_requests) > 0:
@@ -188,7 +188,7 @@ class JiraGitHubCombinedReport(Report):
 
     # variables and method names ending with _1 correspond to the comments part
     def print_report(self, print_comments=False):
-        print "%s (Count = %s) " % (self.header, len(self.github_report.pull_requests))
+        print "{0!s} (Count = {1!s}) ".format(self.header, len(self.github_report.pull_requests))
 
         fields_tuple = ('JIRA ID', 'Pull Request', 'Jira Summary', 'JIRA Age',
                         'Pull Age', 'JIRA Update Age', 'Pull Update Age (Days)',

--- a/dev-tools/test-ns.py
+++ b/dev-tools/test-ns.py
@@ -22,7 +22,7 @@ import os
 os.chdir("storm-core")
 
 ns = sys.argv[1]
-pipe = Popen(["mvn", "test", "-DfailIfNoTests=false", "-Dtest=%s"%ns])
+pipe = Popen(["mvn", "test", "-DfailIfNoTests=false", "-Dtest={0!s}".format(ns)])
 pipe.wait()
 
 os.chdir("..")

--- a/dev-tools/travis/print-errors-from-test-reports.py
+++ b/dev-tools/travis/print-errors-from-test-reports.py
@@ -20,7 +20,7 @@ from xml.etree.ElementTree import ElementTree
 
 def print_detail_information(testcase, fail_or_error):
     print "-" * 50
-    print "classname: %s / testname: %s" % (testcase.get("classname"), testcase.get("name"))
+    print "classname: {0!s} / testname: {1!s}".format(testcase.get("classname"), testcase.get("name"))
     print fail_or_error.text
     stdout = testcase.find("system-out")
     if stdout != None:
@@ -39,7 +39,7 @@ def print_error_reports_from_report_file(file_path):
         tree.parse(file_path)
     except:
         print "-" * 50
-        print "Error parsing %s"%file_path
+        print "Error parsing {0!s}".format(file_path)
         f = open(file_path, "r");
         print f.read();
         print "-" * 50
@@ -64,17 +64,17 @@ def main(report_dir_path):
     for test_report in glob.iglob(report_dir_path + '/*.xml'):
         file_path = os.path.abspath(test_report)
         try:
-            print "Checking %s" % test_report
+            print "Checking {0!s}".format(test_report)
             print_error_reports_from_report_file(file_path)
         except Exception, e:
-            print "Error while reading report file, %s" % file_path
-            print "Exception: %s" % e
+            print "Error while reading report file, {0!s}".format(file_path)
+            print "Exception: {0!s}".format(e)
             traceback.print_exc()
 
 
 if __name__ == "__main__":
     if sys.argv < 2:
-        print "Usage: %s [report dir path]" % sys.argv[0]
+        print "Usage: {0!s} [report dir path]".format(sys.argv[0])
         sys.exit(1)
 
     main(sys.argv[1])

--- a/dev-tools/travis/save-logs.py
+++ b/dev-tools/travis/save-logs.py
@@ -33,7 +33,7 @@ def main(file, cmd):
         count = count + 1
         if datetime.now() > nextPrint:
             diff = datetime.now() - start
-            sys.stdout.write("\r%d seconds %d log lines"%(diff.seconds, count))
+            sys.stdout.write("\r{0:d} seconds {1:d} log lines".format(diff.seconds, count))
             sys.stdout.flush()
             nextPrint = datetime.now() + timedelta(seconds=10)
         out.write(line)
@@ -41,14 +41,14 @@ def main(file, cmd):
     out.close()
     errcode = process.wait()
     diff = datetime.now() - start
-    sys.stdout.write("\r%d seconds %d log lines"%(diff.seconds, count))
+    sys.stdout.write("\r{0:d} seconds {1:d} log lines".format(diff.seconds, count))
     print
     print cmd, "done", errcode
     return errcode
 
 if __name__ == "__main__":
     if sys.argv < 1:
-        print "Usage: %s [file info]" % sys.argv[0]
+        print "Usage: {0!s} [file info]".format(sys.argv[0])
         sys.exit(1)
 
     sys.exit(main(sys.argv[1], sys.argv[2:]))

--- a/storm-core/src/py/storm/DistributedRPC.py
+++ b/storm-core/src/py/storm/DistributedRPC.py
@@ -102,7 +102,7 @@ class Processor(Iface, TProcessor):
     if name not in self._processMap:
       iprot.skip(TType.STRUCT)
       iprot.readMessageEnd()
-      x = TApplicationException(TApplicationException.UNKNOWN_METHOD, 'Unknown function %s' % (name))
+      x = TApplicationException(TApplicationException.UNKNOWN_METHOD, 'Unknown function {0!s}'.format((name)))
       oprot.writeMessageBegin(name, TMessageType.EXCEPTION, seqid)
       x.write(oprot)
       oprot.writeMessageEnd()
@@ -208,9 +208,9 @@ class execute_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -300,9 +300,9 @@ class execute_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__

--- a/storm-core/src/py/storm/DistributedRPCInvocations.py
+++ b/storm-core/src/py/storm/DistributedRPCInvocations.py
@@ -178,7 +178,7 @@ class Processor(Iface, TProcessor):
     if name not in self._processMap:
       iprot.skip(TType.STRUCT)
       iprot.readMessageEnd()
-      x = TApplicationException(TApplicationException.UNKNOWN_METHOD, 'Unknown function %s' % (name))
+      x = TApplicationException(TApplicationException.UNKNOWN_METHOD, 'Unknown function {0!s}'.format((name)))
       oprot.writeMessageBegin(name, TMessageType.EXCEPTION, seqid)
       x.write(oprot)
       oprot.writeMessageEnd()
@@ -325,9 +325,9 @@ class result_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -391,9 +391,9 @@ class result_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -456,9 +456,9 @@ class fetchRequest_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -535,9 +535,9 @@ class fetchRequest_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -600,9 +600,9 @@ class failRequest_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -666,9 +666,9 @@ class failRequest_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__

--- a/storm-core/src/py/storm/Nimbus.py
+++ b/storm-core/src/py/storm/Nimbus.py
@@ -1861,7 +1861,7 @@ class Processor(Iface, TProcessor):
     if name not in self._processMap:
       iprot.skip(TType.STRUCT)
       iprot.readMessageEnd()
-      x = TApplicationException(TApplicationException.UNKNOWN_METHOD, 'Unknown function %s' % (name))
+      x = TApplicationException(TApplicationException.UNKNOWN_METHOD, 'Unknown function {0!s}'.format((name)))
       oprot.writeMessageBegin(name, TMessageType.EXCEPTION, seqid)
       x.write(oprot)
       oprot.writeMessageEnd()
@@ -2959,9 +2959,9 @@ class submitTopology_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3053,9 +3053,9 @@ class submitTopology_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3172,9 +3172,9 @@ class submitTopologyWithOpts_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3266,9 +3266,9 @@ class submitTopologyWithOpts_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3331,9 +3331,9 @@ class killTopology_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3411,9 +3411,9 @@ class killTopology_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3490,9 +3490,9 @@ class killTopologyWithOpts_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3570,9 +3570,9 @@ class killTopologyWithOpts_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3635,9 +3635,9 @@ class activate_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3715,9 +3715,9 @@ class activate_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3780,9 +3780,9 @@ class deactivate_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3860,9 +3860,9 @@ class deactivate_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3939,9 +3939,9 @@ class rebalance_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4033,9 +4033,9 @@ class rebalance_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4112,9 +4112,9 @@ class setLogConfig_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4158,9 +4158,9 @@ class setLogConfig_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4223,9 +4223,9 @@ class getLogConfig_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4288,9 +4288,9 @@ class getLogConfig_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4392,9 +4392,9 @@ class debug_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4472,9 +4472,9 @@ class debug_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4551,9 +4551,9 @@ class setWorkerProfiler_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4597,9 +4597,9 @@ class setWorkerProfiler_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4688,9 +4688,9 @@ class getComponentPendingProfileActions_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4761,9 +4761,9 @@ class getComponentPendingProfileActions_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4840,9 +4840,9 @@ class uploadNewCredentials_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4934,9 +4934,9 @@ class uploadNewCredentials_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5013,9 +5013,9 @@ class beginCreateBlob_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5105,9 +5105,9 @@ class beginCreateBlob_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5170,9 +5170,9 @@ class beginUpdateBlob_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5262,9 +5262,9 @@ class beginUpdateBlob_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5340,9 +5340,9 @@ class uploadBlobChunk_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5406,9 +5406,9 @@ class uploadBlobChunk_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5471,9 +5471,9 @@ class finishBlobUpload_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5537,9 +5537,9 @@ class finishBlobUpload_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5602,9 +5602,9 @@ class cancelBlobUpload_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5668,9 +5668,9 @@ class cancelBlobUpload_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5733,9 +5733,9 @@ class getBlobMeta_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5826,9 +5826,9 @@ class getBlobMeta_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5905,9 +5905,9 @@ class setBlobMeta_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5985,9 +5985,9 @@ class setBlobMeta_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6050,9 +6050,9 @@ class beginBlobDownload_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6143,9 +6143,9 @@ class beginBlobDownload_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6208,9 +6208,9 @@ class downloadBlobChunk_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6286,9 +6286,9 @@ class downloadBlobChunk_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6351,9 +6351,9 @@ class deleteBlob_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6431,9 +6431,9 @@ class deleteBlob_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6496,9 +6496,9 @@ class listBlobs_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6561,9 +6561,9 @@ class listBlobs_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6626,9 +6626,9 @@ class getBlobReplication_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6718,9 +6718,9 @@ class getBlobReplication_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6796,9 +6796,9 @@ class updateBlobReplication_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6888,9 +6888,9 @@ class updateBlobReplication_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6953,9 +6953,9 @@ class createStateInZookeeper_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6999,9 +6999,9 @@ class createStateInZookeeper_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7045,9 +7045,9 @@ class beginFileUpload_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7123,9 +7123,9 @@ class beginFileUpload_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7201,9 +7201,9 @@ class uploadChunk_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7267,9 +7267,9 @@ class uploadChunk_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7332,9 +7332,9 @@ class finishFileUpload_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7398,9 +7398,9 @@ class finishFileUpload_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7463,9 +7463,9 @@ class beginFileDownload_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7541,9 +7541,9 @@ class beginFileDownload_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7606,9 +7606,9 @@ class downloadChunk_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7684,9 +7684,9 @@ class downloadChunk_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7730,9 +7730,9 @@ class getNimbusConf_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7808,9 +7808,9 @@ class getNimbusConf_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7854,9 +7854,9 @@ class getClusterInfo_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7933,9 +7933,9 @@ class getClusterInfo_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7998,9 +7998,9 @@ class getTopologyInfo_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8091,9 +8091,9 @@ class getTopologyInfo_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8170,9 +8170,9 @@ class getTopologyInfoWithOpts_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8263,9 +8263,9 @@ class getTopologyInfoWithOpts_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8354,9 +8354,9 @@ class getTopologyPageInfo_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8447,9 +8447,9 @@ class getTopologyPageInfo_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8551,9 +8551,9 @@ class getComponentPageInfo_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8644,9 +8644,9 @@ class getComponentPageInfo_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8709,9 +8709,9 @@ class getTopologyConf_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8801,9 +8801,9 @@ class getTopologyConf_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8866,9 +8866,9 @@ class getTopology_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8959,9 +8959,9 @@ class getTopology_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9024,9 +9024,9 @@ class getUserTopology_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9117,9 +9117,9 @@ class getUserTopology_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9182,9 +9182,9 @@ class getTopologyHistory_args:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9261,9 +9261,9 @@ class getTopologyHistory_result:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__

--- a/storm-core/src/py/storm/ttypes.py
+++ b/storm-core/src/py/storm/ttypes.py
@@ -342,9 +342,9 @@ class JavaObjectArg:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -433,9 +433,9 @@ class JavaObject:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -479,9 +479,9 @@ class NullStruct:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -561,9 +561,9 @@ class GlobalStreamId:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -731,9 +731,9 @@ class Grouping:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -821,9 +821,9 @@ class StreamInfo:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -899,9 +899,9 @@ class ShellComponent:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -992,9 +992,9 @@ class ComponentObject:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -1123,9 +1123,9 @@ class ComponentCommon:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -1207,9 +1207,9 @@ class SpoutSpec:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -1291,9 +1291,9 @@ class Bolt:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -1375,9 +1375,9 @@ class StateSpoutSpec:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -1526,9 +1526,9 @@ class StormTopology:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -1596,9 +1596,9 @@ class AlreadyAliveException(TException):
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -1666,9 +1666,9 @@ class NotAliveException(TException):
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -1736,9 +1736,9 @@ class AuthorizationException(TException):
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -1806,9 +1806,9 @@ class InvalidTopologyException(TException):
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -1876,9 +1876,9 @@ class KeyNotFoundException(TException):
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -1946,9 +1946,9 @@ class KeyAlreadyExistsException(TException):
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -2730,9 +2730,9 @@ class TopologySummary:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -2919,9 +2919,9 @@ class SupervisorSummary:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3046,9 +3046,9 @@ class NimbusSummary:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3183,9 +3183,9 @@ class ClusterSummary:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3291,9 +3291,9 @@ class ErrorInfo:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3523,9 +3523,9 @@ class BoltStats:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3680,9 +3680,9 @@ class SpoutStats:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3760,9 +3760,9 @@ class ExecutorSpecificStats:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3913,9 +3913,9 @@ class ExecutorStats:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -3995,9 +3995,9 @@ class ExecutorInfo:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4138,9 +4138,9 @@ class ExecutorSummary:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -4216,9 +4216,9 @@ class DebugOptions:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5037,9 +5037,9 @@ class TopologyInfo:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5167,9 +5167,9 @@ class CommonAggregateStats:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5232,9 +5232,9 @@ class SpoutAggregateStats:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5336,9 +5336,9 @@ class BoltAggregateStats:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5416,9 +5416,9 @@ class SpecificAggregateStats:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5523,9 +5523,9 @@ class ComponentAggregateStats:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -5690,9 +5690,9 @@ class TopologyStats:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6546,9 +6546,9 @@ class TopologyPageInfo:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6626,9 +6626,9 @@ class ExecutorAggregateStats:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6930,9 +6930,9 @@ class ComponentPageInfo:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -6995,9 +6995,9 @@ class KillOptions:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7096,9 +7096,9 @@ class RebalanceOptions:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7173,9 +7173,9 @@ class Credentials:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7254,9 +7254,9 @@ class SubmitOptions:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7349,9 +7349,9 @@ class AccessControl:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7438,9 +7438,9 @@ class SettableBlobMeta:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7521,9 +7521,9 @@ class ReadableBlobMeta:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7611,9 +7611,9 @@ class ListBlobsResult:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7706,9 +7706,9 @@ class BeginDownloadResult:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -7915,9 +7915,9 @@ class SupervisorInfo:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8005,9 +8005,9 @@ class NodeInfo:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8096,9 +8096,9 @@ class WorkerResources:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8290,9 +8290,9 @@ class Assignment:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8370,9 +8370,9 @@ class TopologyActionOptions:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8567,9 +8567,9 @@ class StormBase:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8691,9 +8691,9 @@ class ClusterWorkerHeartbeat:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8773,9 +8773,9 @@ class ThriftSerializedObject:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8851,9 +8851,9 @@ class LocalStateData:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -8956,9 +8956,9 @@ class LocalAssignment:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9023,9 +9023,9 @@ class LSSupervisorId:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9100,9 +9100,9 @@ class LSApprovedWorkers:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9178,9 +9178,9 @@ class LSSupervisorAssignments:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9299,9 +9299,9 @@ class LSWorkerHeartbeat:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9427,9 +9427,9 @@ class LSTopoHistory:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9503,9 +9503,9 @@ class LSTopoHistoryList:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9599,9 +9599,9 @@ class ProfileRequest:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9664,9 +9664,9 @@ class GetInfoOptions:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9783,9 +9783,9 @@ class LogLevel:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9860,9 +9860,9 @@ class LogConfig:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -9933,9 +9933,9 @@ class TopologyHistoryInfo:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -10015,9 +10015,9 @@ class DRPCRequest:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -10085,9 +10085,9 @@ class DRPCExecutionException(TException):
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -10219,9 +10219,9 @@ class HBMessageData:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -10311,9 +10311,9 @@ class HBMessage:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -10381,9 +10381,9 @@ class HBAuthorizationException(TException):
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -10451,9 +10451,9 @@ class HBExecutionException(TException):
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -10531,9 +10531,9 @@ class HBPulse:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -10605,9 +10605,9 @@ class HBRecords:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
@@ -10678,9 +10678,9 @@ class HBNodes:
     return value
 
   def __repr__(self):
-    L = ['%s=%r' % (key, value)
+    L = ['{0!s}={1!r}'.format(key, value)
       for key, value in self.__dict__.iteritems()]
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(L))
 
   def __eq__(self, other):
     return isinstance(other, self.__class__) and self.__dict__ == other.__dict__

--- a/storm-multilang/python/src/main/resources/resources/storm.py
+++ b/storm-multilang/python/src/main/resources/resources/storm.py
@@ -170,9 +170,9 @@ class Tuple(object):
         self.values = values
 
     def __repr__(self):
-        return '<%s%s>' % (
+        return '<{0!s}{1!s}>'.format(
             self.__class__.__name__,
-            ''.join(' %s=%r' % (k, self.__dict__[k]) for k in sorted(self.__dict__.keys())))
+            ''.join(' {0!s}={1!r}'.format(k, self.__dict__[k]) for k in sorted(self.__dict__.keys())))
 
     def is_heartbeat_tuple(self):
         return self.task == -1 and self.stream == "__heartbeat"


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:storm?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:storm?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
